### PR TITLE
Toy dataset info added to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,49 @@ conda activate aerial-conversion-dev
 pip install -r requirements.txt
 ```
 
+
+
+## Dataset
+
+A toy dataset has been uploaded to Roboflow. It is a small subset, containing Chatswood region, available [here](https://universe.roboflow.com/sih-vpfnf/gis-hd-200x200).
+
+There are multiple versions of this dataset. Please ignore the first version. Version 2 and later versions are the ones that are being used. The main difference of version 2 and 3 is that [version 2](https://universe.roboflow.com/sih-vpfnf/gis-hd-200x200/2) contains 90 degree augmentaions, while [version 3](https://universe.roboflow.com/sih-vpfnf/gis-hd-200x200/3) does not.
+
+For implementing this in your code, you can use the following code snippet:
+
+```python
+from roboflow import Roboflow
+ 
+rf = Roboflow(api_key= 'your_roboflow_api_key' )
+workspace_name = "sih-vpfnf" 
+dataset_version = 3 
+project_name = "gis-hd-200x200" 
+dataset_download_name = "coco-segmentation" 
+
+project = rf.workspace(workspace_name).project(project_name)
+dataset = project.version(dataset_version).download(dataset_download_name)
+```
+<!-- 
+# Register the dataset
+from detectron2.data.datasets import register_coco_instances
+dataset_name = "chatswood-dataset" #@param {type:"string"}
+dataset_folder = "gis-hd-200x200" #@param {type:"string"}
+register_coco_instances(f"{dataset_name}_train", {}, f"{dataset_folder}/train/_annotations.coco.json", f"/content/{dataset_folder}/train/")
+register_coco_instances(f"{dataset_name}_val", {}, f"{dataset_folder}/valid/_annotations.coco.json", f"/content/{dataset_folder}/valid/")
+register_coco_instances(f"{dataset_name}_test", {}, f"{dataset_folder}/test/_annotations.coco.json", f"/content/{dataset_folder}/test/")
+
+# Use the dataset
+from detectron2.config import get_cfg
+
+cfg = get_cfg()
+cfg.DATASETS.TRAIN = (f"{dataset_name}_train",)
+cfg.DATASETS.TEST = (f"{dataset_name}_test",)
+# then do the other configs
+
+``` -->
+
+
+
 ## Usage
 
 ```


### PR DESCRIPTION
Per [this issue](https://github.com/Sydney-Informatics-Hub/PIPE-3956-aerial-segmentation/issues/7), a toy dataset is created and the links are added to the readme docs.