### PR TITLE
Coco updates aerialseg

### DIFF
--- a/aerial_conversion/coco.py
+++ b/aerial_conversion/coco.py
@@ -19,10 +19,10 @@ class coco_json:
     """Class to hold the coco json format.
 
     Attributes:
-        coco_image (coco_image): coco_image object
-        coco_images (coco_images): coco_images object
-        coco_poly_ann (coco_poly_ann): coco_poly_ann object
-        coco_poly_anns (coco_poly_anns): coco_poly_anns object
+        coco_image (coco_image): coco_image object. The class is intended to hold the meta data, instead of actual image arrays.
+        coco_images (coco_images): coco_images object containing a list of coco_image objects.
+        coco_poly_ann (coco_poly_ann): coco_poly_ann object containing a single polygon annotation.
+        coco_poly_anns (coco_poly_anns): coco_poly_anns object containing a list of coco_poly_ann objects.
     """
 
     def toJSON(self):

--- a/aerial_conversion/coco.py
+++ b/aerial_conversion/coco.py
@@ -6,6 +6,7 @@ import os
 import geopandas as gpd
 import pandas as pd
 import rasterio as rio
+from PIL import Image
 from shapely.geometry import Polygon
 
 """A collectio of functions and structures for reading, writing, and creating
@@ -149,6 +150,45 @@ def raster_to_coco(
     image.id = index
 
     return image
+
+
+def create_coco_image_object_png(image_path: str, index: int):
+    """Function to create a COCO image object.
+
+    Args:
+        image_path (str): Path to image
+        index (int): Index of image
+
+    Returns:
+        image (coco_image): COCO image object
+    """
+    im = Image.open("whatever.png")
+
+    image = coco_json.coco_image()
+    image.license = 1
+    image.file_name = os.path.basename(image_path)
+    image.width, image.height = im.size
+    image.id = index
+
+    return image
+
+
+def create_coco_images_object_png(image_path_list: list):
+    """Function to create a COCO images object.
+
+    Args:
+        image_path_list (list): List of image paths
+
+    Returns:
+        images (coco_images): coco_images object
+    """
+    images = coco_json.coco_images()
+    images.images = [
+        create_coco_image_object_png(image_path, index)
+        for index, image_path in enumerate(image_path_list)
+    ]
+
+    return images
 
 
 def coco_bbox(polygon):

--- a/aerial_conversion/coco.py
+++ b/aerial_conversion/coco.py
@@ -158,7 +158,7 @@ def raster_to_coco(
 
 
 def create_coco_image_object_png(image_path: str, index: int):
-    """Function to create a COCO image object.
+    """Function to create a COCO image (coco_json.coco_image) object.
 
     Args:
         image_path (str): Path to image
@@ -179,7 +179,7 @@ def create_coco_image_object_png(image_path: str, index: int):
 
 
 def create_coco_images_object_png(image_path_list: list):
-    """Function to create a COCO images object.
+    """Function to create a COCO images (coco_json.coco_images) object.
 
     Args:
         image_path_list (list): List of image paths

--- a/aerial_conversion/coco.py
+++ b/aerial_conversion/coco.py
@@ -64,13 +64,19 @@ def make_category(
     return category
 
 
-def make_category_object(geojson: gpd.GeoDataFrame, class_column: str, trim: int):
+def make_category_object(
+    geojson: gpd.GeoDataFrame,
+    class_column: str,
+    trim: int,
+    supercategory_default: str = "landuse",
+):
     """Function to build a COCO categories object.
 
     Args:
         geojson (gpd.GeoDataFrame): GeoDataFrame containing class data
         class_column (str): Name of column containing class names
         trim (int): Number of characters to trim from class name
+        supercategory_default (str, optional): Default supercategory of classes. Defaults to "landuse".
 
     Returns:
         categories_json (list): List of COCO category objects
@@ -78,14 +84,13 @@ def make_category_object(geojson: gpd.GeoDataFrame, class_column: str, trim: int
 
     # TODO: Implement way to read supercategory data.
 
-    supercategory = "landuse"
     classes = pd.DataFrame(geojson[class_column].unique(), columns=["class"])
     classes["class_id"] = classes.index
     categories_json = []
 
     for _, row in classes.iterrows():
         categories_json.append(
-            make_category(row["class"], row["class_id"], supercategory, trim)
+            make_category(row["class"], row["class_id"], supercategory_default, trim)
         )
 
     return categories_json
@@ -162,7 +167,7 @@ def create_coco_image_object_png(image_path: str, index: int):
     Returns:
         image (coco_image): COCO image object
     """
-    im = Image.open("whatever.png")
+    im = Image.open(image_path)
 
     image = coco_json.coco_image()
     image.license = 1

--- a/scripts/geojson2coco.py
+++ b/scripts/geojson2coco.py
@@ -73,7 +73,7 @@ def main(args=None):
         "--tile-dir",
         required=True,
         type=Path,
-        help="Folder path to store the cut raster tiles.",
+        help="Path to where the cut raster tiles should be stored.",
     )
     ap.add_argument(
         "--class-column",
@@ -85,7 +85,7 @@ def main(args=None):
         "--json-name",
         default="coco_from_gis.json",
         type=Path,
-        help="Path to where the output coco file should be stored.",
+        help="Path to the output COCO JSON file.",
     )
     ap.add_argument(
         "--crs", type=str, default=None, help="Specifiy the project crs to use."
@@ -132,7 +132,7 @@ def main(args=None):
         "--info",
         required=True,
         type=Path,
-        help="Path to info description in COCO JSON format. This can be an empty json file.",
+        help="Path to info description in COCO JSON format. This can be an empty file.",
     )
     args = ap.parse_args(args)
 

--- a/scripts/geojson2coco.py
+++ b/scripts/geojson2coco.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+"""This script supports converting a vector shapefile and raster file into a
+COCO format dataset."""
+# -*- coding: utf-8 -*-
 import argparse
 import glob
 import logging
@@ -47,21 +50,43 @@ def assemble_coco_json(
 
 def main(args=None):
     ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument("--polygon-file", required=True, default=".", type=Path)
-    ap.add_argument("--raster-file", required=True, type=Path)
+    ap.add_argument(
+        "--polygon-file",
+        required=True,
+        default=".",
+        type=Path,
+        help="Path to a georeferenced shapefile polygon vector file (e.g. geoJSON) that contains annotations for the raster file.",
+    )
+    ap.add_argument(
+        "--raster-file",
+        required=True,
+        type=Path,
+        help="Path to the raster file (e.g. geoTIFF).",
+    )
     ap.add_argument(
         "--tile-size",
         default=1000,
         type=int,
         help="Int length in meters of square tiles to generate from raster. Defaults to 1000 meters.",
     )
-    ap.add_argument("--tile-dir", required=True, type=Path)
+    ap.add_argument(
+        "--tile-dir",
+        required=True,
+        type=Path,
+        help="Folder path to store the cut raster tiles.",
+    )
     ap.add_argument(
         "--class-column",
+        required=True,
         type=str,
         help="Column name in GeoJSON where classes are stored.",
     )
-    ap.add_argument("--json-name", default="coco_from_gis.json", type=Path)
+    ap.add_argument(
+        "--json-name",
+        default="coco_from_gis.json",
+        type=Path,
+        help="Path to where the output coco file should be stored.",
+    )
     ap.add_argument(
         "--crs", type=str, default=None, help="Specifiy the project crs to use."
     )
@@ -107,7 +132,7 @@ def main(args=None):
         "--info",
         required=True,
         type=Path,
-        help="Path to info description in COCO JSON format.",
+        help="Path to info description in COCO JSON format. This can be an empty json file.",
     )
     args = ap.parse_args(args)
 


### PR DESCRIPTION
Additional functionalities are added in this version to allow working with [aerialseg](https://github.com/Sydney-Informatics-Hub/aerial-segmentation).

In this PR, the `coco` module is updated so we can create `coco_image` and `coco_images` objects from PNG files as well, in addition to raster files. This will enable us to generate a COCO output from predictions on PNG files.

This PR is necessary to satisfy [aerial-segmentation #24 ](https://github.com/Sydney-Informatics-Hub/aerial-segmentation/issues/24).
