### PR TITLE
handled warnings for gpd area calculation and rio transform

### DIFF
--- a/aerial_conversion/coco.py
+++ b/aerial_conversion/coco.py
@@ -140,6 +140,7 @@ def raster_to_coco(
             dtype=geotiff.dtypes[0],
             nodata=0,
             compress="deflate",
+            transform=geotiff.profile["transform"],
         ) as dst:
             if colour is False:
                 dst.write(raster, 1)

--- a/aerial_conversion/coordinates.py
+++ b/aerial_conversion/coordinates.py
@@ -188,8 +188,12 @@ def get_tile_polygons(raster_tile: str, geojson: gpd.GeoDataFrame, filter: int =
     # Split multipolygon
     tile_polygons = tile_polygons.explode(index_parts=False)
     tile_polygons = tile_polygons.reset_index(drop=True)
-    # Filter out zero area polygons
+
+    # Filter out zero area polygons by re-projecting to the best UTM CRS for area calculation
+    target_crs = tile_polygons.estimate_utm_crs()
+    tile_polygons = tile_polygons.to_crs(target_crs)
     tile_polygons = tile_polygons[tile_polygons.geometry.area > filter]
+    tile_polygons = tile_polygons.to_crs(geojson.crs)
     # if filter is True:
     #     tile_polygons = tile_polygons[tile_polygons.geometry.area > 5000]
     tile_polygons = tile_polygons.reset_index(drop=True)


### PR DESCRIPTION
As https://github.com/Sydney-Informatics-Hub/aerial-conversion/issues/25.

Also specified `transform` in `coco.py` function `raster_to_coco()` to deal with the warning:
```
NotGeoreferencedWarning: Dataset has no geotransform, gcps, or rpcs. The identity matrix will be returned.
  dataset = writer(
```