### PR TITLE
Some minor fixes to the batch_geojson2coco.py script

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ python -m aerial_conversion.scripts.coco2geojson \
 To do a batch conversion, when the conversion should be carried on multiple input images, use the following command:
 
 ```
-python -m aerial_conversion.scripts.batch_coco2geojson \
+python -m aerial_conversion.scripts.batch_geojson2coco \
                 --raster-dir /path/to/data/rasters/ \
                 --vector-dir /path/to/data/geojsons/ \
                 --output-dir /path/to/data/outputs/ \

--- a/scripts/batch_geojson2coco.py
+++ b/scripts/batch_geojson2coco.py
@@ -91,8 +91,7 @@ def process_single(args):
 
                 # Construct the command
                 command = [
-                    "python",
-                    "scripts/geojson2coco.py",
+                    "geojson2coco",
                     "--raster-file",
                     os.path.join(args.raster_dir, raster_file),
                     "--polygon-file",
@@ -102,7 +101,7 @@ def process_single(args):
                     "--json-name",
                     json_file,
                     "--offset",
-                    overlap,
+                    str(overlap),
                     "--info",
                     info_file,
                     "--tile-size",
@@ -110,7 +109,6 @@ def process_single(args):
                     "--class-column",
                     args.class_column,
                 ]
-
                 try:
                     # Run the command
                     subprocess.run(command, capture_output=True, text=True, check=True)
@@ -133,7 +131,6 @@ def process_single(args):
         pickle.dump(error, f)
 
     return individual_coco_datasets
-
 
 
 def main(args=None):


### PR DESCRIPTION
1. Run the installed `geojson2coco` script rather than from the hardcoded `scripts/geojson2coco.py`
2. Ensure `overlap` is a string before passing it to `subprocess.run`

Also a minor correction to the README to point to the correct batch script name.