### PR TITLE
Conversion re split merged tiles

### DIFF
--- a/aerial_conversion/coco.py
+++ b/aerial_conversion/coco.py
@@ -107,6 +107,7 @@ def make_category_object(
     categories_json = []
 
     log.info(f"Making category object with {len(classes)} classes.")
+    log.info(f"The classes df is {str(classes)}")
 
     for _, row in classes.iterrows():
         categories_json.append(

--- a/aerial_conversion/coco.py
+++ b/aerial_conversion/coco.py
@@ -100,9 +100,13 @@ def make_category_object(
 
     # TODO: Implement way to read supercategory data.
 
+    log.debug(f"Making category object from {class_column} column.")
+
     classes = pd.DataFrame(geojson[class_column].unique(), columns=["class"])
     classes["class_id"] = classes.index
     categories_json = []
+
+    log.info(f"Making category object with {len(classes)} classes.")
 
     for _, row in classes.iterrows():
         categories_json.append(

--- a/aerial_conversion/coco.py
+++ b/aerial_conversion/coco.py
@@ -15,7 +15,7 @@ from shapely.geometry import Polygon
 
 from .orthogonalise import orthogonalise
 
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.WARNING)
 log = logging.getLogger(__name__)
 
 

--- a/aerial_conversion/coco.py
+++ b/aerial_conversion/coco.py
@@ -15,6 +15,7 @@ from shapely.geometry import Polygon
 
 from .orthogonalise import orthogonalise
 
+logging.basicConfig(level=logging.DEBUG)
 log = logging.getLogger(__name__)
 
 
@@ -70,7 +71,7 @@ def make_category(
     Returns:
         category (dict): COCO category object
     """
-
+    log.debug(f"Making category for {class_name} with ID {class_id}.")
     category = {
         "supercategory": supercategory,
         "id": int(class_id),

--- a/drafts/refactored_batch_geojson2coco.py
+++ b/drafts/refactored_batch_geojson2coco.py
@@ -1,0 +1,223 @@
+import argparse
+import json
+import os
+import pickle
+import subprocess
+import pandas as pd
+from pycocotools.coco import COCO
+from tqdm import tqdm
+
+
+def crop_and_save_geojson(raster_dir, geojson_path, raster_extension=".tif"):
+    """Crop a GeoJSON file to the extent of a raster file and save it.
+
+    Args:
+        raster_dir (str): Path to the directory containing the raster files.
+        geojson_path (str): Path to the GeoJSON file.
+        raster_extension (str, optional): Extension of the raster files. Defaults to '.tif'.
+    """
+
+    # Read the GeoJSON file
+    geojson = gpd.read_file(geojson_path)
+
+    # Loop through each raster file
+    for raster_file in os.listdir(raster_dir):
+        if raster_file.endswith(raster_extension):
+            raster_path = os.path.join(raster_dir, raster_file)
+
+            # Open the raster file and get its bounds
+            with rasterio.open(raster_path) as src:
+                left, bottom, right, top = src.bounds
+
+            # Create a bounding box from the raster bounds
+            bbox = box(left, bottom, right, top)
+
+            # Crop the GeoJSON to the extent of the raster
+            cropped_geojson = geojson[geojson.geometry.intersects(bbox)]
+
+            # Save the cropped GeoJSON with the same naming pattern
+            cropped_geojson_filename = (
+                os.path.dirname(geojson_path)
+                + "/"
+                + os.path.basename(raster_file).split(".")[0]
+                + ".geojson"
+            )
+            cropped_geojson.to_file(cropped_geojson_filename, driver="GeoJSON")
+
+
+def get_processed(output_dir):
+    """
+    Retrieve the list of directories already processed into COCO format.
+
+    Args:
+        output_dir (str): Path to the output directory.
+
+    Returns:
+        list: A list of directory names that are already processed.
+    """
+    processed = []
+    for sub_dir in os.listdir(output_dir):
+        json_path = os.path.join(output_dir, sub_dir, "coco_from_gis.json")
+        if os.path.isfile(json_path):
+            processed.append(sub_dir)
+    return processed
+
+def run_conversion(raster_dir, vector_dir, output_dir, resume=False, **kwargs):
+    """
+    Run the batch conversion of raster and geojson vector data into COCO datasets.
+
+    Args:
+        raster_dir (str): Path to the raster data directory.
+        vector_dir (str): Path to the vector data (geojson) directory.
+        output_dir (str): Path where COCO datasets will be saved.
+        resume (bool): Whether to resume a previously incomplete job.
+
+    Additional kwargs supported are:
+        tile_size (int): The size of the tile in meters.
+        class_column (str): The column to use as class names from geojson.
+        overlap (float): The overlap between tiles as a percentage.
+        pattern (str): The pattern to match geojson filenames with raster files.
+        info (str): Path to the directory containing info JSON files.
+
+    Returns:
+        list: A list of paths to individual COCO dataset files.
+
+    Raises:
+        NotImplementedError: If parallel processing is enabled (not currently supported).
+    """
+    if kwargs.get('no_workers', 1) > 1:
+        raise NotImplementedError("Parallel processing not implemented.")
+
+    processed = get_processed(output_dir) if resume else []
+    coco_datasets = []
+    errors = {}
+
+    # Process each raster file.
+    for raster_file in os.listdir(raster_dir):
+        if not raster_file.endswith(".tif"):
+            continue
+        
+        file_name = os.path.splitext(raster_file)[0]
+        if file_name in processed:
+            print(f"Skipping {file_name} as it is already processed.")
+            coco_datasets.append(os.path.join(output_dir, file_name, "coco_from_gis.json"))
+            continue
+
+        vector_file = f"{file_name}{kwargs.get('pattern', '')}.geojson"
+        vector_path = os.path.join(vector_dir, vector_file)
+        if not os.path.exists(vector_path):
+            continue
+
+        # Specify output paths and prepare directories.
+        pair_output_dir = os.path.join(output_dir, file_name)
+        os.makedirs(pair_output_dir, exist_ok=True)
+        
+        json_file = os.path.join(pair_output_dir, "coco_from_gis.json")
+        info_file = kwargs.get('info', os.path.join(output_dir, "info.json"))
+        if not os.path.isfile(info_file):
+            with open(info_file, "w") as f:
+                json.dump({}, f)
+
+        overlap = kwargs.get('overlap', 0)
+        tile_size = kwargs.get('tile_size', 100)
+        class_column = kwargs.get('class_column')
+        if class_column is None:
+            raise ValueError("class_column argument is required.")
+
+        # Prepare and run the conversion command.
+        command = [
+            "geojson2coco",
+            "--raster-file", os.path.join(raster_dir, raster_file),
+            "--polygon-file", vector_path,
+            "--tile-dir", pair_output_dir,
+            "--json-name", json_file,
+            "--offset", str(overlap),
+            "--info", info_file,
+            "--tile-size", str(tile_size),
+            "--class-column", class_column,
+        ]
+
+        try:
+            subprocess.run(command, capture_output=True, text=True, check=True)
+        except subprocess.CalledProcessError as e:
+            print(f"Error processing {vector_file}: {e.stderr}")
+            errors[file_name] = e.stderr
+            error_df = pd.DataFrame.from_dict({file_name: e.stderr}, orient="index", columns=["error_message"])
+            error_df.to_csv(os.path.join(output_dir, "error.csv"), mode='a')
+        else:
+            coco_datasets.append(json_file)
+
+    # Save the errors and return the path to COCO datasets.
+    with open(os.path.join(output_dir, "error.pkl"), "wb") as f:
+        pickle.dump(errors, f)
+
+    return coco_datasets
+
+def concatenate_coco_datasets(coco_datasets, output_dir):
+    """
+    Concatenate individual COCO datasets into a single COCO dataset.
+
+    Args:
+        coco_datasets (list): A list of paths to individual COCO dataset files.
+        output_dir (str): The directory to save the concatenated COCO dataset.
+
+    Returns:
+        str: The path to the concatenated COCO dataset.
+    """
+    concatenated = COCO(initialize_empty=True)
+    category_index = image_index = annotation_index = 0
+    for coco_file in tqdm(coco_datasets):
+        with open(coco_file, 'r') as f:
+            dataset = json.load(f)
+        for image in dataset['images']:
+            image['file_name'] = os.path.join(os.path.basename(os.path.dirname(coco_file)), image['file_name'])
+            image['id'] = image_index
+            concatenated.addImage(image)
+            image_index += 1
+        for ann in dataset['annotations']:
+            ann['image_id'] = image_index - 1
+            ann['id'] = annotation_index
+            concatenated.addAnns([ann])
+            annotation_index += 1
+        for cat in dataset['categories']:
+            if not concatenated.hasCat(cat['name']):
+                cat['id'] = category_index
+                concatenated.addCats([cat])
+                category_index += 1
+            else:
+                cat['id'] = concatenated.getCatId(cat['name'])
+            
+    concatenated_output_dir = os.path.join(output_dir, "concatenated")
+    os.makedirs(concatenated_output_dir, exist_ok=True)
+    concatenated_json_file = os.path.join(concatenated_output_dir, "concatenated_coco.json")
+    with open(concatenated_json_file, 'w') as f:
+        json.dump(concatenated.dataset, f, indent=2)
+
+    return concatenated_json_file
+
+def main():
+    parser = argparse.ArgumentParser(description="Convert raster and vector pairs to COCO JSON format.")
+    parser.add_argument("--raster-dir", required=True, help="Path to the raster directory.")
+    parser.add_argument("--vector-dir", required=True, help="Path to the vector directory.")
+    parser.add_argument("--output-dir", required=True, help="Path to the output directory.")
+    parser.add_argument("--tile-size", type=int, default=100, help="Tile width/height in meters.")
+    parser.add_argument("--class-column", required=True, help="Column name in GeoJSON for classes.")
+    parser.add_argument("--overlap", default=0, help="Overlap between tiles in percentage.")
+    parser.add_argument("--pattern", default="", help="Pattern to match the vector file names.")
+    parser.add_argument("--concatenate", action="store_true", help="Concatenate individual COCO datasets into one.")
+    parser.add_argument("--info", help="Path to the info JSON file.")
+    parser.add_argument("--resume", action="store_true", help="Resume a batch job from an output directory.")
+    parser.add_argument("--no-workers", type=int, default=1, help="Number of workers to use for parallel processing.")
+    args = parser.parse_args()
+
+    # Run conversion process
+    coco_datasets = run_conversion(args.raster_dir, args.vector_dir, args.output_dir, resume=args.resume, **vars(args))
+    print("Conversion completed.")
+
+    # Optional concatenation of COCO datasets
+    if args.concatenate:
+        concatenated_json_file = concatenate_coco_datasets(coco_datasets, args.output_dir)
+        print(f"Concatenated COCO dataset saved to: {concatenated_json_file}")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/batch_geojson2coco.py
+++ b/scripts/batch_geojson2coco.py
@@ -152,8 +152,9 @@ def process_single(args):
                 # Specify the overlap
                 overlap = args.overlap
 
+                print("The class column is: ", args.class_column)
                 print(
-                    f"Processing {vector_file} | {raster_file} | {info_file} > > > > {json_file}"
+                    f"Processing {vector_file}\t| {raster_file}\t| {info_file} > > > > {json_file}"
                 )
 
                 # Construct the command

--- a/scripts/batch_geojson2coco.py
+++ b/scripts/batch_geojson2coco.py
@@ -22,6 +22,17 @@ logging.basicConfig(level=logging.WARN)
 logger = logging.getLogger(__name__)
 
 
+def string_crop(string, chars):
+    try:
+        if len(string) > chars:
+            chars = chars - 2
+            return ".." + string[-chars:]
+        else:
+            return string
+    except TypeError:
+        return string
+
+
 def resume(output_dir: str) -> list:
     """Resume a batch job from an output directory.
 
@@ -168,7 +179,10 @@ def process_single(args):
 
                 print("The class column is: ", args.class_column)
                 print(
-                    f"Processing {vector_file}\t| {raster_file}\t| {info_file} > > > > {json_file}"
+                    f"Processing:\t vector_file:\t{vector_file}"
+                    + f"\t raster_file:\t{raster_file}"
+                    + f"\t info file:\t{info_file}"
+                    + f"\t json file:\t{json_file}"
                 )
 
                 # Construct the command
@@ -325,13 +339,15 @@ def main(args=None):
     # Generate markdown output for individual COCO datasets
     print("Running geojson2coco.py over raster and vector pairs:")
     print()
-    print("| Raster File\t| Vector File\t| JSON File\t|")
-    print("|------------\t|------------\t|----------\t|")
+    print("| Raster File \t| Vector File \t| JSON File \t|")
+    print("| ----------- \t| ----------- \t| ----------\t|")
     for coco_file in individual_coco_datasets:
         pair_dir = os.path.dirname(coco_file)
         raster_file = os.path.basename(pair_dir) + ".tif"
         vector_file = os.path.basename(pair_dir) + ".geojson"
-        print(f"| {raster_file}\t| {vector_file}\t| {coco_file}\t|")
+        print(
+            f"| {string_crop(raster_file,13)}\t| {string_crop(vector_file,13)}\t| {string_crop(coco_file,11)}\t|"
+        )
 
     # Concatenate COCO datasets if the --concatenate argument is enabled
     if args.concatenate:

--- a/scripts/batch_geojson2coco.py
+++ b/scripts/batch_geojson2coco.py
@@ -22,15 +22,18 @@ logging.basicConfig(level=logging.WARN)
 logger = logging.getLogger(__name__)
 
 
-def string_crop(string, chars):
+def format_string(s, length=23):
     try:
-        if len(string) > chars:
-            chars = chars - 2
-            return ".." + string[-chars:]
+        if len(s) > length:
+            length = length - 3
+            s = "..." + s[-length:]
         else:
-            return string
+            format_specifier = "{:<" + str(length) + "." + str(length) + "}"
+            s = format_specifier.format(s)
+        return s
     except TypeError:
-        return string
+        format_specifier = "{:<" + str(length) + "." + str(length) + "}"
+        return format_specifier.format("NA")
 
 
 def resume(output_dir: str) -> list:
@@ -339,14 +342,18 @@ def main(args=None):
     # Generate markdown output for individual COCO datasets
     print("Running geojson2coco.py over raster and vector pairs:")
     print()
-    print("| Raster File \t| Vector File \t| JSON File \t|")
-    print("| ----------- \t| ----------- \t| ----------\t|")
+    print(
+        "|       Raster File       |       Vector File       |        JSON File        |"
+    )
+    print(
+        "| ----------------------- | ----------------------- | ----------------------- |"
+    )
     for coco_file in individual_coco_datasets:
         pair_dir = os.path.dirname(coco_file)
         raster_file = os.path.basename(pair_dir) + ".tif"
         vector_file = os.path.basename(pair_dir) + ".geojson"
         print(
-            f"| {string_crop(raster_file,13)}\t| {string_crop(vector_file,13)}\t| {string_crop(coco_file,11)}\t|"
+            f"| {format_string(raster_file,23)} | {format_string(vector_file,23)} | {format_string(coco_file,23)} |"
         )
 
     # Concatenate COCO datasets if the --concatenate argument is enabled

--- a/scripts/batch_geojson2coco.py
+++ b/scripts/batch_geojson2coco.py
@@ -67,6 +67,7 @@ def crop_and_save_geojson(
     # Create the cropped directory
     os.makedirs(cropped_dir, exist_ok=True)
 
+    print(f"Cropping {geojson_path} to the extent of the raster files.")
     # Loop through each raster file
     for raster_file in tqdm(os.listdir(raster_dir)):
         if raster_file.endswith(raster_extension):
@@ -102,6 +103,7 @@ def crop_and_save_geojson(
 
 
 def process_single(args):
+    """The main script with a sinle threaded implementation."""
     output_dir = args.output_dir
 
     individual_coco_datasets = []  # List to store individual COCO datasets

--- a/scripts/batch_geojson2coco.py
+++ b/scripts/batch_geojson2coco.py
@@ -35,6 +35,10 @@ def resume(output_dir: str) -> list:
     """
 
     processed = []
+    # Check if the output directory does not exist, then return an empty list
+    if not os.path.exists(output_dir):
+        return processed
+    
     for sub_dir in os.listdir(output_dir):
         # Check for all subdirs
         if os.path.isdir(os.path.join(output_dir, sub_dir)):

--- a/scripts/batch_geojson2coco.py
+++ b/scripts/batch_geojson2coco.py
@@ -300,13 +300,13 @@ def main(args=None):
     # Generate markdown output for individual COCO datasets
     print("Running geojson2coco.py over raster and vector pairs:")
     print()
-    print("| Raster File | Vector File | JSON File |")
-    print("|-------------|-------------|-----------|")
+    print("| Raster File\t| Vector File\t| JSON File\t|")
+    print("|------------\t|------------\t|----------\t|")
     for coco_file in individual_coco_datasets:
         pair_dir = os.path.dirname(coco_file)
         raster_file = os.path.basename(pair_dir) + ".tif"
         vector_file = os.path.basename(pair_dir) + ".geojson"
-        print(f"| {raster_file} | {vector_file} | {coco_file} |")
+        print(f"| {raster_file}\t| {vector_file}\t| {coco_file}\t|")
 
     # Concatenate COCO datasets if the --concatenate argument is enabled
     if args.concatenate:

--- a/scripts/geojson2coco.py
+++ b/scripts/geojson2coco.py
@@ -22,7 +22,7 @@ from aerial_conversion.coco import (
 from aerial_conversion.coordinates import pixel_polygons_for_raster_tiles, wkt_parser
 from aerial_conversion.tiles import save_tiles
 
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.WARNING)
 log = logging.getLogger(__name__)
 
 

--- a/scripts/geojson2coco.py
+++ b/scripts/geojson2coco.py
@@ -22,6 +22,7 @@ from aerial_conversion.coco import (
 from aerial_conversion.coordinates import pixel_polygons_for_raster_tiles, wkt_parser
 from aerial_conversion.tiles import save_tiles
 
+logging.basicConfig(level=logging.DEBUG)
 log = logging.getLogger(__name__)
 
 
@@ -208,11 +209,14 @@ def main(args=None):
     # TODO: make less hacky
     if args.class_column not in geojson.columns:
         # If it doesn't exist, create a new column with the specified name and fill it with the string value of class-column argument
+        log.error(
+            f"Class column {args.class_column} not found in GeoJSON. Will create one instead..."
+        )
         geojson[args.class_column] = args.class_column
     geojson["class_id"] = geojson[class_column].factorize()[0]
-    print("Class column is: ", class_column)
-    print("Class id is: ", geojson["class_id"])
-    print("Trim class is: ", trim_class)
+    log.debug("Class column is: ", class_column)
+    log.debug("Class id is: ", geojson["class_id"])
+    log.debug("Trim class is: ", trim_class)
     categories_json = make_category_object(geojson, class_column, trim_class)
 
     # If license is not supplied, use MIT by default

--- a/scripts/geojson2coco.py
+++ b/scripts/geojson2coco.py
@@ -214,9 +214,9 @@ def main(args=None):
         )
         geojson[args.class_column] = args.class_column
     geojson["class_id"] = geojson[class_column].factorize()[0]
-    log.debug("Class column is: ", class_column)
-    log.debug("Class id is: ", geojson["class_id"])
-    log.debug("Trim class is: ", trim_class)
+    log.debug("Class column is: %s", class_column)
+    log.debug("Class id is: %s", geojson["class_id"])
+    log.debug("Trim class is: %s", trim_class)
     categories_json = make_category_object(geojson, class_column, trim_class)
 
     # If license is not supplied, use MIT by default

--- a/scripts/geojson2coco.py
+++ b/scripts/geojson2coco.py
@@ -67,7 +67,7 @@ def main(args=None):
     ap.add_argument(
         "--tile-size",
         default=1000,
-        type=int,
+        type=float,
         help="Int length in meters of square tiles to generate from raster. Defaults to 1000 meters.",
     )
     ap.add_argument(

--- a/scripts/geojson2coco.py
+++ b/scripts/geojson2coco.py
@@ -210,6 +210,9 @@ def main(args=None):
         # If it doesn't exist, create a new column with the specified name and fill it with the string value of class-column argument
         geojson[args.class_column] = args.class_column
     geojson["class_id"] = geojson[class_column].factorize()[0]
+    print("Class column is: ", class_column)
+    print("Class id is: ", geojson["class_id"])
+    print("Trim class is: ", trim_class)
     categories_json = make_category_object(geojson, class_column, trim_class)
 
     # If license is not supplied, use MIT by default

--- a/scripts/geojson2coco.py
+++ b/scripts/geojson2coco.py
@@ -158,6 +158,11 @@ def main(args=None):
     geojson_path = args.polygon_file
     out_path = args.tile_dir
     tile_size = args.tile_size
+    # change tile size to float from string
+    try:
+        tile_size = float(tile_size)
+    except ValueError:
+        pass
     user_crs = args.crs
     class_column = args.class_column
     trim_class = args.trim_class
@@ -200,7 +205,7 @@ def main(args=None):
 
     # Create class_id for category mapping
     # Check if the specified class column exists
-    #TODO: make less hacky
+    # TODO: make less hacky
     if args.class_column not in geojson.columns:
         # If it doesn't exist, create a new column with the specified name and fill it with the string value of class-column argument
         geojson[args.class_column] = args.class_column


### PR DESCRIPTION
The batch conversion script can now get a single geojson file instead of one-to-one geojson files corresponding to the rasters. Based on the rasters, the script creates cropped geojson files from the big geojson. This is done automatically if a vector file is provided instead of a vector dir.
The script also changes the way the file names are matched for rasters and annotations. Now it is expected to have the same file unless a prefix is added to the rasters. This can be considered a mild fix for #37 .
