### PR TITLE
COCO-split integration and Roboflow preprocess

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,21 @@ Please ensure the rasters in the raster directory are named similarly as the geo
 
 `--tile-size` argument is the size of the tiles in meters.
 
+
+## Other Scrpts
+
+### Splitting Dataset
+
+Splitting dataset to train, test, and validation sets can be achieved using the following script:
+
+```bash
+python -m aerial_conversion.scripts.coco_split -s 0.7 /path/to/concatenated_coco.json /path/to/save/output/train.json /path/to/save/output/test_valid.json
+
+python -m aerial_conversion.scripts.coco_split -s 0.667 /path/to/test_valid.json /path/to/save/output/test.json /path/to/save/output/valid.json
+```
+
+
+
 <!-- ---
 
 ## Documentation

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,7 @@ pre-commit
 Sphinx
 sphinx_rtd_theme
 pycocotools
+funcy
+argparse
+scikit-learn
+scikit-multilearn

--- a/scripts/batch_geojson2coco.py
+++ b/scripts/batch_geojson2coco.py
@@ -2,6 +2,7 @@
 """This script supports batch conversion of paired geojson and raster data into
 a series of COCO datasets."""
 import argparse
+import glob
 import json
 import logging
 import os
@@ -283,6 +284,11 @@ def parse_arguments(args):
         help="Force overwrite the cropped GeoJSON file if they exist. Use this to ensure that the GeoJSON files are cropped to the extent of the raster files and up to date.",
     )
     parser.add_argument(
+        "--roboflow_compatible",
+        action=argparse.BooleanOptionalAction,
+        help="If set, will also generate Roboflow compatible JSON and png files in a single directory named Roboflow.",
+    )
+    parser.add_argument(
         "--no-workers",
         type=int,
         default=1,
@@ -481,6 +487,36 @@ def main(args=None):
             json.dump(concatenated_coco.dataset, f, indent=2)
 
         print(f"\nConcatenated COCO dataset saved to: {concatenated_json_file}")
+
+        # Add roboflow compatible JSON and png files in a single directory named Roboflow
+        if args.roboflow_compatible:
+            roboflow_output_dir = os.path.join(args.output_dir, "Roboflow")
+            os.makedirs(roboflow_output_dir, exist_ok=True)
+
+            # Save the concatenated COCO dataset as roboflow compatible JSON
+            roboflow_json_file = os.path.join(roboflow_output_dir, "concatenated.json")
+            with open(roboflow_json_file, "w") as f:
+                json.dump(concatenated_coco.dataset, f, indent=2)
+
+            print(f"Roboflow compatible JSON saved to: {roboflow_json_file}")
+
+            # Open the json file as a text file, then replace all image paths with the updated paths (/tile_ -> _tile_), then save it
+            with open(roboflow_json_file, "r") as f:
+                roboflow_json = f.read()
+            roboflow_json = roboflow_json.replace("/tile_", "_tile_")
+            with open(roboflow_json_file, "w") as f:
+                f.write(roboflow_json)
+
+            # Copy all png files in the subdirectories to the roboflow_output_dir
+            in_pattern = roboflow_json_file.replace("concatenated.json", "/**/*.png")
+            files = glob.glob(in_pattern)
+
+            # Copy files to the out_dir and rename the file to the name of the directory it was in+the file name
+            for file in tqdm(files):
+                # print(file)
+                os.system(
+                    f"cp {file} {os.path.join(roboflow_output_dir,os.path.basename(os.path.dirname(file)))}_{os.path.basename(file)}"
+                )
 
 
 if __name__ == "__main__":

--- a/scripts/coco_split.py
+++ b/scripts/coco_split.py
@@ -1,0 +1,157 @@
+# -*- coding: utf-8 -*-
+"""This is a script to split coco dataset tot train and test datasets.
+
+All credits goes to: https://github.com/akarazniewicz/cocosplit
+"""
+
+import argparse
+import json
+
+import funcy
+import numpy as np
+from sklearn.model_selection import train_test_split
+from skmultilearn.model_selection import iterative_train_test_split
+
+
+def save_coco(file, info, licenses, images, annotations, categories):
+    with open(file, "wt", encoding="UTF-8") as coco:
+        json.dump(
+            {
+                "info": info,
+                "licenses": licenses,
+                "images": images,
+                "annotations": annotations,
+                "categories": categories,
+            },
+            coco,
+            indent=2,
+            sort_keys=True,
+        )
+
+
+def filter_annotations(annotations, images):
+    image_ids = funcy.lmap(lambda i: int(i["id"]), images)
+    return funcy.lfilter(lambda a: int(a["image_id"]) in image_ids, annotations)
+
+
+def filter_images(images, annotations):
+    annotation_ids = funcy.lmap(lambda i: int(i["image_id"]), annotations)
+
+    return funcy.lfilter(lambda a: int(a["id"]) in annotation_ids, images)
+
+
+parser = argparse.ArgumentParser(
+    description="Splits COCO annotations file into training and test sets."
+)
+parser.add_argument(
+    "annotations",
+    metavar="coco_annotations",
+    type=str,
+    help="Path to COCO annotations file.",
+)
+parser.add_argument("train", type=str, help="Where to store COCO training annotations")
+parser.add_argument("test", type=str, help="Where to store COCO test annotations")
+parser.add_argument(
+    "-s",
+    dest="split",
+    type=float,
+    required=True,
+    help="A percentage of a split; a number in (0, 1)",
+)
+parser.add_argument(
+    "--having-annotations",
+    dest="having_annotations",
+    action="store_true",
+    help="Ignore all images without annotations. Keep only these with at least one annotation",
+)
+
+parser.add_argument(
+    "--multi-class",
+    dest="multi_class",
+    action="store_true",
+    help="Split a multi-class dataset while preserving class distributions in train and test sets",
+)
+
+args = parser.parse_args()
+
+
+def main(args):
+    with open(args.annotations, "rt", encoding="UTF-8") as annotations:
+        coco = json.load(annotations)
+        info = coco["info"]
+        licenses = coco["licenses"]
+        images = coco["images"]
+        annotations = coco["annotations"]
+        categories = coco["categories"]
+
+        images_with_annotations = funcy.lmap(lambda a: int(a["image_id"]), annotations)
+
+        if args.having_annotations:
+            images = funcy.lremove(
+                lambda i: i["id"] not in images_with_annotations, images
+            )
+
+        if args.multi_class:
+
+            annotation_categories = funcy.lmap(
+                lambda a: int(a["category_id"]), annotations
+            )
+
+            # bottle neck 1
+            # remove classes that has only one sample, because it can't be split into the training and testing sets
+            annotation_categories = funcy.lremove(
+                lambda i: annotation_categories.count(i) <= 1, annotation_categories
+            )
+
+            annotations = funcy.lremove(
+                lambda i: i["category_id"] not in annotation_categories, annotations
+            )
+
+            X_train, _, X_test, _ = iterative_train_test_split(
+                np.array([annotations]).T,
+                np.array([annotation_categories]).T,
+                test_size=1 - args.split,
+            )
+
+            save_coco(
+                args.train,
+                info,
+                licenses,
+                filter_images(images, X_train.reshape(-1)),
+                X_train.reshape(-1).tolist(),
+                categories,
+            )
+            save_coco(
+                args.test,
+                info,
+                licenses,
+                filter_images(images, X_test.reshape(-1)),
+                X_test.reshape(-1).tolist(),
+                categories,
+            )
+
+            print(
+                "Saved {} entries in {} and {} in {}".format(
+                    len(X_train), args.train, len(X_test), args.test
+                )
+            )
+
+        else:
+
+            X_train, X_test = train_test_split(images, train_size=args.split)
+
+            anns_train = filter_annotations(annotations, X_train)
+            anns_test = filter_annotations(annotations, X_test)
+
+            save_coco(args.train, info, licenses, X_train, anns_train, categories)
+            save_coco(args.test, info, licenses, X_test, anns_test, categories)
+
+            print(
+                "Saved {} entries in {} and {} in {}".format(
+                    len(anns_train), args.train, len(anns_test), args.test
+                )
+            )
+
+
+if __name__ == "__main__":
+    main(args)


### PR DESCRIPTION
- To upload the dataset to Roboflow, the PNG files are better in a single directory, with a proper COCO JSON file. This has been added to the `batch_geojson2coco` script.

- The split function taken from an [external repo](https://github.com/akarazniewicz/cocosplit) is embedded into the scripts, so we won't need to install and modify the env every time. Please check to see if this will create any licensing issue.